### PR TITLE
Security Fix for Arbitrary Code Execution - huntr.dev

### DIFF
--- a/server/Infra.data.js
+++ b/server/Infra.data.js
@@ -40,7 +40,7 @@ var server = http.createServer(function (req, res) {
 			console.log('BODY length: ' + chunk.length);
 			try {
 				var body = yaml.safeLoad(chunk);
-			}catch(err){
+			} catch(err) {
 				res.writeHead(400, {'Content-Type': 'text/plain'});
 				res.write( "Bad request");
 				res.end();
@@ -93,9 +93,9 @@ var server = http.createServer(function (req, res) {
 		} 
 		if(req.method == 'PUT') {
 			console.log('BODY: ' + chunk);
-			try{
+			try {
 				var body = yaml.safeLoad(chunk);
-			}catch(err){
+			} catch(err) {
 				res.writeHead(400, {'Content-Type': 'text/plain'});
 				res.write( "Bad request");
 				res.end();

--- a/server/Infra.data.js
+++ b/server/Infra.data.js
@@ -38,8 +38,15 @@ var server = http.createServer(function (req, res) {
 		if(req.method == 'POST') {
 			console.log('BODY: ' + chunk);
 			console.log('BODY length: ' + chunk.length);
-			var body = yaml.load(chunk);
-			
+			try {
+				var body = yaml.safeLoad(chunk);
+			}catch(err){
+				res.writeHead(400, {'Content-Type': 'text/plain'});
+				res.write( "Bad request");
+				res.end();
+				console.log("Problem loading yaml");
+				return
+			}
 			if (body.hasOwnProperty("cod")) {
 				key = body.cod + "." + body.tag + "." + body.author;
 			} else {
@@ -86,8 +93,16 @@ var server = http.createServer(function (req, res) {
 		} 
 		if(req.method == 'PUT') {
 			console.log('BODY: ' + chunk);
-			var body = yaml.load(chunk);
-			
+			try{
+				var body = yaml.safeLoad(chunk);
+			}catch(err){
+				res.writeHead(400, {'Content-Type': 'text/plain'});
+				res.write( "Bad request");
+				res.end();
+				console.log("Problem loading yaml");
+				return
+			}
+
 			var filename;
 			if (body.hasOwnProperty("cod")) {
 				filename = body.cod + "." + body.tag + "." + body.author ;


### PR DESCRIPTION
https://huntr.dev/users/alromh87 has fixed the Arbitrary Code Execution vulnerability 🔨. alromh87 has been awarded $25 for fixing the vulnerability through the huntr bug bounty program 💵. Think you could fix a vulnerability like this?
           
Get involved at https://huntr.dev/

Q | A
Version Affected | ALL
Bug Fix | YES
Original Pull Request | https://github.com/418sec/Infra/pull/2
Vulnerability README | https://github.com/418sec/huntr/blob/master/bounties/npm/infraserver/1/README.md

### User Comments:

### 📊 Metadata *

infraserver is a data server, this package are vulnerable to Arbitrary Code Execution due to the default usage of the function load() of the package js-yaml instead of its secure replacement, safeLoad().

It took my a little while to implement the POC properly, but now its cleanly solved

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-infraserver

### ⚙️ Description *

I replaced the use of yaml.load() with yaml.safeLoad() and added handling of error if loading fails.

### 💻 Technical Description *

Two vulnerable endpoints where found on infra POST and PUT

Code execution is avoided by using yamlLoad(), but just replacing the function (as the other PR) malicious payload would trigger DoS, so I avoided that by using try ... catch.

### 🐛 Proof of Concept (PoC) *

1. Download Infra
`git clone https://github.com/xuemen/Infra`
2. Enter directory
`cd infra`
3. Start server
`node server/Infra.data.js`
4. Create poc.py
```python
#!/bin/python
# -*- coding: utf-8 -*-

import requests

print ('Post request -----------------------')
r = requests.post('http://localhost:46372', data="hasOwnProperty: !<tag:yaml.org,2002:js/function> ' () => {console.log(`This is code executed on the server, started from payload`)}' ")
print (r)
print (r.text)

print ('\n\n\n')

print ('Put request ------------------------')
r = requests.put('http://localhost:46372', data="hasOwnProperty: !<tag:yaml.org,2002:js/function> ' () => {console.log(`This is code executed on the server, started from payload`)}' ")
print (r)
print (r.text)
```
5. Execute poc
`python poc.py`
6. Server will execute injected code printing **This is code executed on the server, started from payload** to console and then die causing DoS

### Before fix
![Captura de pantalla de 2020-09-11 19-28-53](https://user-images.githubusercontent.com/7505980/92953673-d118de00-f46a-11ea-906b-b87d512edfb4.png)

### Only repleacing use of function (incomplete fix)
![Captura de pantalla de 2020-09-11 19-36-52](https://user-images.githubusercontent.com/7505980/92953884-29e87680-f46b-11ea-987e-47d8714e2320.png)

### 🔥 Proof of Fix (PoF) *

After fix no code is executed and server stays online

![Captura de pantalla de 2020-09-11 19-42-52](https://user-images.githubusercontent.com/7505980/92953896-2fde5780-f46b-11ea-8126-18097237bd7e.png)


### 👍 User Acceptance Testing (UAT)

Functionality unafected

![Captura de pantalla de 2020-09-11 20-27-42](https://user-images.githubusercontent.com/7505980/92955137-4be2f880-f46d-11ea-9c18-fd8c90963729.png)
